### PR TITLE
날짜가 국가별로 다르게 표시되는지 확인

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -26,7 +26,8 @@ export const TripCard: React.FC<TripCardProps> = ({
     return new Date(dateString).toLocaleDateString('ko-KR', {
       year: 'numeric',
       month: 'long',
-      day: 'numeric'
+      day: 'numeric',
+      timeZone: 'Asia/Seoul',
     });
   };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { Trip } from '../types/trip';
 import { Plus, Plane, MapPin, Calendar } from 'lucide-react';
 import { collection, query, where, onSnapshot, orderBy, doc, deleteDoc } from 'firebase/firestore';
 import { db } from '../lib/firebase';
+import { todayIsoKst } from '../utils/time';
 
 export const Home: React.FC = () => {
   const { user, loading: authLoading } = useAuth();
@@ -128,7 +129,10 @@ export const Home: React.FC = () => {
               <GlassCard variant="light" className="text-center p-4 animate-fade-in">
                 <Plane className="w-8 h-8 text-travel-purple mx-auto mb-2" />
                 <div className="text-2xl font-bold text-white">
-                  {trips.filter(trip => new Date(trip.end_date) < new Date()).length}
+                  {(() => {
+                    const todayKst = todayIsoKst();
+                    return trips.filter(trip => (trip.end_date || '') < todayKst).length;
+                  })()}
                 </div>
                 <div className="text-white/60 text-sm">완료</div>
               </GlassCard>

--- a/src/pages/PlaceSearch.tsx
+++ b/src/pages/PlaceSearch.tsx
@@ -116,7 +116,7 @@ const PlaceCard: React.FC<PlaceCardProps> = ({ place, onSelect, onToggleFavorite
             </div>
             {place.created_at && (
               <span>
-                {place.created_at.toDate().toLocaleDateString('ko-KR')}
+                {place.created_at.toDate().toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}
               </span>
             )}
           </div>

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -14,6 +14,7 @@ import { doc, getDoc, setDoc, Timestamp, collection } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { storage } from '../lib/firebase';
+import { addDaysYmd, getUtcWeekday, getUtcYmdParts } from '../utils/time';
 
 export const PlanDetail: React.FC = () => {
   const { tripId, planId } = useParams<{ tripId: string; planId: string }>();
@@ -249,18 +250,15 @@ export const PlanDetail: React.FC = () => {
 
   const getDayWithDate = (dayNumber: number) => {
     if (!trip) return `Day ${dayNumber}`;
-    
-    const start = new Date(trip.start_date);
-    const targetDate = new Date(start);
-    targetDate.setDate(start.getDate() + dayNumber - 1);
-    
-    const year = targetDate.getFullYear();
-    const month = String(targetDate.getMonth() + 1).padStart(2, '0');
-    const date = String(targetDate.getDate()).padStart(2, '0');
+
+    const target = addDaysYmd(trip.start_date, dayNumber - 1);
+    const { year, month, day } = getUtcYmdParts(target);
+    const mm = String(month).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
     const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
-    const dayName = dayNames[targetDate.getDay()];
-    
-    return `Day ${dayNumber} (${year}.${month}.${date}.${dayName})`;
+    const dayName = dayNames[getUtcWeekday(target)];
+
+    return `Day ${dayNumber} (${year}.${mm}.${dd}.${dayName})`;
   };
 
   const validateForm = () => {

--- a/src/pages/TripMap.tsx
+++ b/src/pages/TripMap.tsx
@@ -27,6 +27,7 @@ import {
 import { db } from '../lib/firebase';
 import { Trip } from '../types/trip';
 import { Plan } from '../types/plan';
+import { addDaysYmd, getUtcWeekday, getUtcYmdParts } from '../utils/time';
 
 export const TripMap: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -196,17 +197,15 @@ export const TripMap: React.FC = () => {
 
   const getDayWithDate = (dayNumber: number) => {
     if (!trip) return `Day ${dayNumber}`;
-    
-    const start = new Date(trip.start_date);
-    const targetDate = new Date(start);
-    targetDate.setDate(start.getDate() + dayNumber - 1);
-    
-    const month = String(targetDate.getMonth() + 1).padStart(2, '0');
-    const date = String(targetDate.getDate()).padStart(2, '0');
+
+    const target = addDaysYmd(trip.start_date, dayNumber - 1);
+    const { month, day } = getUtcYmdParts(target);
+    const mm = String(month).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
     const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
-    const dayName = dayNames[targetDate.getDay()];
-    
-    return `${month}.${date}.${dayName}`;
+    const dayName = dayNames[getUtcWeekday(target)];
+
+    return `${mm}.${dd}.${dayName}`;
   };
 
   const days = trip ? Array.from({ length: getTripDuration() }, (_, i) => i + 1) : [];

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,78 @@
+export const KST_TIMEZONE = 'Asia/Seoul';
+
+const DEFAULT_DATE_OPTS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  timeZone: KST_TIMEZONE,
+};
+
+/**
+ * Parses a YYYY-MM-DD string into a Date representing UTC midnight for that date.
+ * This avoids local timezone side effects when doing day-based arithmetic.
+ */
+export function toDateFromYmdUtc(ymd: string): Date {
+  const [yearStr, monthStr, dayStr] = ymd.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/** Formats a Date or YYYY-MM-DD as ko-KR date fixed to KST. */
+export function formatDateKst(
+  dateInput: Date | number | string,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    ...DEFAULT_DATE_OPTS,
+    ...(options || {}),
+    timeZone: KST_TIMEZONE,
+  };
+  const dateObj =
+    typeof dateInput === 'string'
+      ? toDateFromYmdUtc(dateInput)
+      : new Date(dateInput);
+  return dateObj.toLocaleDateString('ko-KR', opts);
+}
+
+/** Returns YYYY-MM-DD in KST for a given Date or YYYY-MM-DD input. */
+export function formatKstYmd(dateInput: Date | number | string): string {
+  const d =
+    typeof dateInput === 'string'
+      ? toDateFromYmdUtc(dateInput)
+      : new Date(dateInput);
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: KST_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return formatter.format(d);
+}
+
+/** Today as YYYY-MM-DD in KST. */
+export function todayIsoKst(): string {
+  return formatKstYmd(new Date());
+}
+
+/** Adds delta days to a YYYY-MM-DD and returns a Date object (UTC-based). */
+export function addDaysYmd(ymd: string, deltaDays: number): Date {
+  const base = toDateFromYmdUtc(ymd).getTime();
+  const added = base + deltaDays * 24 * 60 * 60 * 1000;
+  return new Date(added);
+}
+
+/** Extracts YYYY, MM, DD from a Date using UTC getters to avoid local tz. */
+export function getUtcYmdParts(date: Date): { year: number; month: number; day: number } {
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+/** Returns 0-6 weekday using UTC to avoid local tz. */
+export function getUtcWeekday(date: Date): number {
+  return date.getUTCDay();
+}


### PR DESCRIPTION
Unify all date displays and "completed" trip calculations to KST for global consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dccfcac-14e1-42fc-9155-9e8e449b8eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dccfcac-14e1-42fc-9155-9e8e449b8eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

